### PR TITLE
Replace bitnami base image with nginxinc/nginx-unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM bitnami/nginx:1.25.1
+FROM nginxinc/nginx-unprivileged:1.28-alpine@sha256:7377697a821c131a924a7105fafbe7414db4e9fcc77a6f08f776f33f141ec3f8
 
 WORKDIR /app
 
-COPY ./src .
+COPY ./src /usr/share/nginx/html


### PR DESCRIPTION
The current `bitnami/nginx` image is no longer available so needs replacing with a current unprivileged version of `nginx`.